### PR TITLE
Added a script to detect API container port

### DIFF
--- a/detect_api_port.mjs
+++ b/detect_api_port.mjs
@@ -1,0 +1,59 @@
+import  { spawn } from 'child_process';
+
+const containerName = 'trueblocks';
+
+// This command will print string like 0.0.0.0:8090->80/tcp
+// which means [IP address of the container]:[container port] -> [port inside of the container]/[protocol]
+// We want it this way, so that it is easier to parse
+const command = ['docker', ['ps', `-f name=${containerName}`, `--format='{{.Ports}}'`]];
+
+function spawnDockerCommand() {
+    return spawn(...command);
+}
+
+// Because we can read stdout and stderr through pipes only, we need to bind some functions to pipe events
+function bindListeners(process, { onData, onError, onClose }) {
+    process.stdout.on('data', onData);
+    process.stderr.on('data', onError);
+    process.on('close', onClose);
+}
+
+// This gets the port number
+function parseCommandOutput(output) {
+    return output.replace(/.+:([\d]{4}).+/, '$1').trim();
+}
+
+// Runs docker command and binds events to pipes (stdout and stderr)
+function executeCommand() {
+    const dockerCommandProcess = spawnDockerCommand();
+
+    return new Promise((resolve, reject) => {
+        bindListeners(dockerCommandProcess, {
+            onData(data) {
+                resolve(data.toString());
+            },
+            onError(error) {
+                reject(error.toString());
+            },
+            onClose() {
+                reject(new Error('Cannot read port number - is API container running?'));
+            }
+        });
+    });
+}
+
+async function detectPort() {
+    const commandOutput = await executeCommand();
+    const port = parseCommandOutput(commandOutput);
+
+    return port;
+}
+
+(async () => {
+    try {
+        const port = await detectPort();
+        console.log(port);
+    } catch (e) {
+        throw new Error(`Error while getting API port ${e}`);
+    }
+})();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "./",
   "private": true,
   "scripts": {
-    "start-docker": "PORT=3002 REACT_APP_API_URL=http://localhost REACT_APP_API_PORT=80 react-scripts start",
+    "start-docker": "PORT=3002 REACT_APP_API_URL=http://localhost REACT_APP_API_PORT=`node ./detect_api_port.mjs` react-scripts start",
     "start": "PORT=3002 react-scripts start",
     "start-log-scraper": "chifra scrape run 1>$HOME/.quickBlocks/cache/tmp/scraper.log 2>&1 &",
     "start-scraper": "chifra scrape run 1>/dev/null 2>&1 &",


### PR DESCRIPTION
This script will detect API port and print it, so that it can be used as a part of another command (see the change to `package.json`)

This requires Node version >= 14, if we want to support lower versions just ping me and I will convert this code to CommonJS module