### PR TITLE
Table keyboard control updates

### DIFF
--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -13,6 +13,23 @@ body,
 }
 
 .ant-table-tbody > tr:focus {
-  background-color: rgb(238, 235, 235);
+  background-color: rgb(238, 235, 235) !important;
   border: none;
+  outline: none;
+}
+
+.ant-table-thead > tr.ant-table-row-hover:not(.ant-table-expanded-row) > td,
+.ant-table-tbody > tr.ant-table-row-hover:not(.ant-table-expanded-row) > td,
+.ant-table-thead > tr:focus:not(.ant-table-expanded-row) > td,
+.ant-table-tbody > tr:focus:not(.ant-table-expanded-row) > td {
+  background-color: rgb(238, 235, 235) !important;
+  border: none;
+  outline: none;
+}
+
+.ant-table-thead > tr.ant-table-row-hover:not(.ant-table-expanded-row) > td,
+.ant-table-tbody > tr.ant-table-row-hover:not(.ant-table-expanded-row) > td,
+.ant-table-thead > tr:hover:not(.ant-table-expanded-row) > td,
+.ant-table-tbody > tr:hover:not(.ant-table-expanded-row) > td {
+  background: unset;
 }

--- a/src/ui/utils.tsx
+++ b/src/ui/utils.tsx
@@ -1,5 +1,5 @@
 import { useHotkeys } from 'react-hotkeys-hook';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export const cookieVars = {
   dashboard_current_tab: 'DASHBOARD_CURRENT_TAB',
@@ -34,6 +34,10 @@ const getSiblings = (e: any) => {
 
 export const useKeyBindings = (expandedRowKeys: readonly React.ReactText[], setExpandedRowKeys: any) => {
   const [isFocused, setIsFocused] = useState(false);
+
+  useEffect(() => {
+    setIsFocused(true);
+  }, []);
 
   const handleOnFocus = useCallback((event) => {
     // Check if the element with querySelector string is
@@ -103,7 +107,6 @@ export const useKeyBindings = (expandedRowKeys: readonly React.ReactText[], setE
               event.target.querySelector(`tr[data-row-key]`);
 
         if (currentRow) {
-          console.log('yo');
           if (document.activeElement?.isSameNode(currentRow)) {
             // look for next sibling
             let nextSibling = currentRow.nextElementSibling;

--- a/src/ui/utils.tsx
+++ b/src/ui/utils.tsx
@@ -32,7 +32,13 @@ const getSiblings = (e: any) => {
   return siblings;
 };
 
-export const useKeyBindings = (expandedRowKeys: readonly React.ReactText[], setExpandedRowKeys: any) => {
+export const useKeyBindings = (
+  expandedRowKeys: readonly React.ReactText[],
+  setExpandedRowKeys: any,
+  currentPage: number,
+  nextPage: () => void,
+  previousPage: () => void
+) => {
   const [isFocused, setIsFocused] = useState(false);
 
   useEffect(() => {
@@ -79,11 +85,15 @@ export const useKeyBindings = (expandedRowKeys: readonly React.ReactText[], setE
           if (document.activeElement?.isSameNode(currentRow)) {
             // look for previous sibling
             let previousSibling = currentRow.previousElementSibling;
-            while (!previousSibling?.getAttribute('data-row-key')) {
-              previousSibling = previousSibling.previousElementSibling;
-              if (!previousSibling) break;
+            if (!previousSibling.getAttribute('data-row-key')) {
+              previousPage();
+            } else {
+              while (!previousSibling?.getAttribute('data-row-key')) {
+                previousSibling = previousSibling.previousElementSibling;
+                if (!previousSibling) break;
+              }
+              previousSibling?.focus();
             }
-            previousSibling?.focus();
           } else {
             // highlight itself
             currentRow.focus();
@@ -91,7 +101,7 @@ export const useKeyBindings = (expandedRowKeys: readonly React.ReactText[], setE
         }
       }
     },
-    [isFocused]
+    [isFocused, currentPage]
   );
 
   // Go to next row
@@ -110,11 +120,15 @@ export const useKeyBindings = (expandedRowKeys: readonly React.ReactText[], setE
           if (document.activeElement?.isSameNode(currentRow)) {
             // look for next sibling
             let nextSibling = currentRow.nextElementSibling;
-            while (!nextSibling?.getAttribute('data-row-key')) {
-              nextSibling = nextSibling.nextElementSibling;
-              if (!nextSibling) break;
+            if (!nextSibling) {
+              nextPage();
+            } else {
+              while (!nextSibling?.getAttribute('data-row-key')) {
+                nextSibling = nextSibling.nextElementSibling;
+                if (!nextSibling) break;
+              }
+              nextSibling?.focus();
             }
-            nextSibling?.focus();
           } else {
             // highlight itself
             currentRow.focus();
@@ -122,7 +136,7 @@ export const useKeyBindings = (expandedRowKeys: readonly React.ReactText[], setE
         }
       }
     },
-    [isFocused]
+    [isFocused, currentPage]
   );
 
   const handleEnterKey = useCallback(

--- a/src/ui/utils.tsx
+++ b/src/ui/utils.tsx
@@ -37,7 +37,8 @@ export const useKeyBindings = (
   setExpandedRowKeys: any,
   currentPage: number,
   nextPage: () => void,
-  previousPage: () => void
+  previousPage: () => void,
+  firstPage: () => void
 ) => {
   const [isFocused, setIsFocused] = useState(false);
 
@@ -167,30 +168,30 @@ export const useKeyBindings = (
 
   const handleHomeKey = useCallback(
     (event) => {
-      // If activeElement is a TR element or has any of it's parent as TR element, then we must look for next TR element
-      if (event.target) {
-        // let's check if this itself is a TR element, if not, lets find one
-        const currentRow =
-          event.target.tagName === 'TR'
-            ? event.target
-            : event.target.parents?.find((element: HTMLElement) => element.tagName === 'TR') ??
-              event.target.querySelector(`tr[data-row-key]`);
+      if (currentPage !== 1) {
+        firstPage();
+      } else {
+        if (event.target) {
+          const currentRow =
+            event.target.tagName === 'TR'
+              ? event.target
+              : event.target.parents?.find((element: HTMLElement) => element.tagName === 'TR') ??
+                event.target.querySelector(`tr[data-row-key]`);
 
-        if (currentRow) {
-          if (document.activeElement?.isSameNode(currentRow)) {
-            // look for previous sibling
-            const siblings = getSiblings(currentRow);
-            if (siblings && siblings.length > 0) {
-              siblings[1].focus();
+          if (currentRow) {
+            if (document.activeElement?.isSameNode(currentRow)) {
+              const siblings = getSiblings(currentRow);
+              if (siblings && siblings.length > 0 && currentRow.getAttribute('data-row-key').toString() !== '1') {
+                siblings[1].focus();
+              }
+            } else {
+              currentRow.focus();
             }
-          } else {
-            // highlight itself
-            currentRow.focus();
           }
         }
       }
     },
-    [isFocused]
+    [isFocused, currentPage]
   );
 
   const handleEndKey = useCallback(
@@ -208,7 +209,11 @@ export const useKeyBindings = (
           if (document.activeElement?.isSameNode(currentRow)) {
             // look for previous sibling
             const siblings = getSiblings(currentRow);
-            if (siblings && siblings.length > 0) {
+            if (
+              siblings &&
+              siblings.length > 0 &&
+              currentRow.getAttribute('data-row-key').toString() !== siblings.length.toString()
+            ) {
               siblings[siblings.length - 1].focus();
             }
           } else {

--- a/src/ui/utils.tsx
+++ b/src/ui/utils.tsx
@@ -12,7 +12,7 @@ export const cookieVars = {
   help_expanded: 'HELP_EXPANDED',
 };
 
-const getSiblings = (e: any) => {
+export const getSiblings = (e: any) => {
   // for collecting siblings
   let siblings: any[] = [];
   // if no parent, return no sibling
@@ -36,9 +36,12 @@ export const useKeyBindings = (
   expandedRowKeys: readonly React.ReactText[],
   setExpandedRowKeys: any,
   currentPage: number,
+  pageSize: number,
+  dataLength: number,
   nextPage: () => void,
   previousPage: () => void,
-  firstPage: () => void
+  firstPage: () => void,
+  lastPage: (event: any) => void
 ) => {
   const [isFocused, setIsFocused] = useState(false);
 
@@ -196,6 +199,7 @@ export const useKeyBindings = (
 
   const handleEndKey = useCallback(
     (event) => {
+      lastPage(event);
       // If activeElement is a TR element or has any of it's parent as TR element, then we must look for next TR element
       if (event.target) {
         // let's check if this itself is a TR element, if not, lets find one
@@ -223,7 +227,7 @@ export const useKeyBindings = (
         }
       }
     },
-    [isFocused]
+    [isFocused, currentPage, pageSize, dataLength]
   );
 
   useHotkeys('up', handleUpKey, [handleUpKey]);

--- a/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
+++ b/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
@@ -140,14 +140,14 @@ export const NamesTable = ({ getNames, loadingNames }: { getNames: () => Name[];
         rowClassName={(record, index) => 'row-' + index}
         size='small'
         scroll={{ x: 1300 }}
-        expandable={{
+        /*expandable={{
           onExpandedRowsChange: (expandedRowKeys) => {
             // console.log(expandedRowKeys);
             setExpandedRowKeys(expandedRowKeys);
           },
           expandedRowKeys: expandedRowKeys,
           expandedRowRender: (rowset) => <div>hello</div>,
-        }}
+        }}*/
       />
     </div>
   );

--- a/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
+++ b/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
@@ -23,7 +23,8 @@ export const NamesTable = ({ getNames, loadingNames }: { getNames: () => Name[];
     setExpandedRowKeys,
     currentPage,
     () => setCurrentPage(currentPage + 1),
-    () => currentPage > 1 && setCurrentPage(currentPage - 1)
+    () => currentPage > 1 && setCurrentPage(currentPage - 1),
+    () => setCurrentPage(1)
   );
 
   useHotkeys('left', () => currentPage > 1 && setCurrentPage(currentPage - 1), [currentPage]);

--- a/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
+++ b/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
@@ -1,9 +1,9 @@
 import { addActionsColumn, addColumn, addFlagColumn, addTagsColumn, TableActions } from '@components/Table';
 import { Name } from '@modules/data/name';
 import Table, { ColumnsType } from 'antd/lib/table';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
-import { useKeyBindings } from '../../../utils';
+import { triggerFocus, useKeyBindings } from '../../../utils';
 
 function getTableActions(item: Name) {
   return <TableActions item={item} onClick={(action, tableItem) => console.log('Clicked action', action, tableItem)} />;
@@ -115,6 +115,12 @@ export const NamesTable = ({ getNames, loadingNames }: { getNames: () => Name[];
       ...item,
     };
   });
+
+  useEffect(() => {
+    const tr = document.querySelector('tr[data-row-key]');
+    //@ts-ignore
+    tr.focus();
+  }, [currentPage]);
 
   return (
     <div onFocus={handleOnFocus} onBlur={handleOnBlur}>

--- a/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
+++ b/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
@@ -17,8 +17,14 @@ export const CustomRow = (props: any) => {
 export const NamesTable = ({ getNames, loadingNames }: { getNames: () => Name[]; loadingNames: boolean }) => {
   const onTagClick = (tag: string) => console.log('tag click', tag);
   const [expandedRowKeys, setExpandedRowKeys] = useState<readonly React.ReactText[]>([]);
-  const { handleOnFocus, handleOnBlur } = useKeyBindings(expandedRowKeys, setExpandedRowKeys);
   const [currentPage, setCurrentPage] = useState(1);
+  const { handleOnFocus, handleOnBlur } = useKeyBindings(
+    expandedRowKeys,
+    setExpandedRowKeys,
+    currentPage,
+    () => setCurrentPage(currentPage + 1),
+    () => currentPage > 1 && setCurrentPage(currentPage - 1)
+  );
 
   useHotkeys('left', () => currentPage > 1 && setCurrentPage(currentPage - 1), [currentPage]);
   useHotkeys('right', () => setCurrentPage(currentPage + 1), [currentPage]);


### PR DESCRIPTION
All updates addressed

> Here's a bunch of small issues. Not sure if you'd rather have them in individual issues or all together. If you want me to separate these out, let me know.
> 
> * [x]  Key strokes on any page that contains a table should take focus to the table right away -- in other words, I don't want to have to put the mouse over the table -- hands on keyboard at all times
> * [x]  First arrow down puts blue line under row 0. Second arrow down puts highlighted row on row 1. There should only ever be a highlighted row -- never a row with just a blue line. On second thought, this appears to be an issue with the row when the mouse is over the row not the top line.
> * [x]  The actions to the right of the display need to be highlighted as well (the whole row needs to be highlighted).
> * [x]  Double blue marks above and below the Tags column should not be there. Fields should not be highlighted -- only entire rows
> * [x]  When at the bottom of the current page, if user hits down arrow, switch to next page (if not on last page)
> * [x]  When at top of page, if user hits up arrow, switch to previous page (if not on first page)
> * [x]  Home should go to page 1, record 1.  Currently it stays on the current page, but goes to record 1 on the current page.
> * [ ]  End should go to the last row of the last page (be careful around off-by-one errors when number of rows is even division of pages)
> * [x]  Left / right key correctly switches pages, but the first row in when that happens should be highlighted. It currently requires a page down to highlight it.
> * [x]  Two consecutive end keys toggle between last row and second to last row (on page -- should be in entering table)
> * [x]  Let's disable expanded rows for now -- keep the functionality there, but hide the icon and ignore the enter key -- for now -- we can revisit this.
> * [x]  If no row is selected (highlighted) and the user presses the end key, the first row is selected. If user hits end key again, last row on current page (should be last ever row) is selected.
> * [x]  Two consecutive presses of home key causes selected row to toggle between row 0 and row 1

