### PR TITLE
Fix table keyboard bugs

### DIFF
--- a/src/ui/utils.tsx
+++ b/src/ui/utils.tsx
@@ -182,6 +182,7 @@ export const useKeyBindings = (
   const handleHomeKey = useCallback(
     (event) => {
       if (currentPage !== 1) {
+        setFocusedRow(0);
         firstPage();
       } else {
         if (event.target) {
@@ -195,7 +196,7 @@ export const useKeyBindings = (
             if (document.activeElement?.isSameNode(currentRow)) {
               const siblings = getSiblings(currentRow);
               if (siblings && siblings.length > 0 && currentRow.getAttribute('data-row-key').toString() !== '1') {
-                setFocusedRow(1);
+                setFocusedRow(0);
                 siblings[1].focus();
               }
             } else {

--- a/src/ui/utils.tsx
+++ b/src/ui/utils.tsx
@@ -91,7 +91,7 @@ export const useKeyBindings = (
           if (document.activeElement?.isSameNode(currentRow)) {
             // look for previous sibling
             let previousSibling = currentRow.previousElementSibling;
-            if (!previousSibling.getAttribute('data-row-key')) {
+            if (!previousSibling.getAttribute('data-row-key') && currentPage !== 1) {
               previousPage();
             } else {
               while (!previousSibling?.getAttribute('data-row-key')) {

--- a/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
+++ b/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
@@ -68,8 +68,6 @@ export const NamesTable = ({ getNames, loadingNames }: { getNames: () => Name[];
     [currentPage, dataSource, focusedRow, setFocusedRow]
   );
 
-  console.log(focusedRow);
-
   const components = {
     body: { row: CustomRow },
   };
@@ -182,9 +180,15 @@ export const NamesTable = ({ getNames, loadingNames }: { getNames: () => Name[];
         pagination={{
           current: currentPage,
           pageSize: pageSize,
-          onChange: (page, pageSize) => {
+          onChange: (page, newPageSize) => {
             setCurrentPage(page);
-            pageSize && setPageSize(pageSize);
+            if (newPageSize !== pageSize) {
+              setPageSize(pageSize);
+              setCurrentPage(1);
+              const tr = document.querySelector('tr[data-row-key]');
+              //@ts-ignore
+              tr.focus();
+            }
           },
         }}
         rowClassName={(record, index) => 'row-' + index}

--- a/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
+++ b/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
@@ -19,7 +19,7 @@ export const NamesTable = ({ getNames, loadingNames }: { getNames: () => Name[];
   const [expandedRowKeys, setExpandedRowKeys] = useState<readonly React.ReactText[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
-  const [focusedRow, setFocusedRow] = useState(1);
+  const [focusedRow, setFocusedRow] = useState(0);
 
   const dataSource = getNames().map((item, i) => {
     return {
@@ -67,6 +67,8 @@ export const NamesTable = ({ getNames, loadingNames }: { getNames: () => Name[];
     },
     [currentPage, dataSource, focusedRow, setFocusedRow]
   );
+
+  console.log(focusedRow);
 
   const components = {
     body: { row: CustomRow },


### PR DESCRIPTION
Fixes the following issues:

> Issue 1
> Go to names table
> Hit home
> Hit up arrow key
> Should do nothing....scrolls to bottom of current page instead.
> 
> Issue 2
> Rows per page control captures keyboard control if changed.
> 
> On any page, confirm that keyboard control works
> Change the number of rows per page control (notice it captures keyboard control)
> Hit next/prev key or nextpage/prevpage. Row selection does not work
> Suggestion: after changing rows per page value return to first page and select the first row in the table.
> Note that the same does not happen if one clicks on page link directly.
> Issue 3
> Hit the home key
> Hit down arrow once (selected row is now second row on page)
> Hit next page key
> The selected row is correctly the second row on the page. All good
> Hot the home key again (first row is selected)
> Hit next page key
> Fourth row on page is selected -- would have expected first row to be selected.