### PR TITLE
Keyboard control updates

### DIFF
--- a/src/ui/utils.tsx
+++ b/src/ui/utils.tsx
@@ -182,6 +182,7 @@ export const useKeyBindings = (
   const handleHomeKey = useCallback(
     (event) => {
       if (currentPage !== 1) {
+        setFocusedRow(0);
         firstPage();
       } else {
         if (event.target) {
@@ -195,7 +196,7 @@ export const useKeyBindings = (
             if (document.activeElement?.isSameNode(currentRow)) {
               const siblings = getSiblings(currentRow);
               if (siblings && siblings.length > 0 && currentRow.getAttribute('data-row-key').toString() !== '1') {
-                setFocusedRow(1);
+                setFocusedRow(0);
                 siblings[1].focus();
               }
             } else {

--- a/src/ui/utils.tsx
+++ b/src/ui/utils.tsx
@@ -91,7 +91,7 @@ export const useKeyBindings = (
           if (document.activeElement?.isSameNode(currentRow)) {
             // look for previous sibling
             let previousSibling = currentRow.previousElementSibling;
-            if (!previousSibling.getAttribute('data-row-key')) {
+            if (!previousSibling.getAttribute('data-row-key') && currentPage !== 1) {
               previousPage();
             } else {
               while (!previousSibling?.getAttribute('data-row-key')) {

--- a/src/ui/utils.tsx
+++ b/src/ui/utils.tsx
@@ -225,10 +225,11 @@ export const useKeyBindings = (
           if (document.activeElement?.isSameNode(currentRow)) {
             // look for previous sibling
             const siblings = getSiblings(currentRow);
+            const currentRowString = currentRow.getAttribute('data-row-key').toString();
             if (
               siblings &&
               siblings.length > 0 &&
-              currentRow.getAttribute('data-row-key').toString() !== siblings.length.toString()
+              currentRowString.charAt(currentRowString.length - 1) !== siblings.length.toString()
             ) {
               setFocusedRow(siblings.length - 1);
               siblings[siblings.length - 1].focus();

--- a/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
+++ b/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
@@ -68,8 +68,6 @@ export const NamesTable = ({ getNames, loadingNames }: { getNames: () => Name[];
     [currentPage, dataSource, focusedRow, setFocusedRow]
   );
 
-  console.log(focusedRow);
-
   const components = {
     body: { row: CustomRow },
   };
@@ -182,9 +180,15 @@ export const NamesTable = ({ getNames, loadingNames }: { getNames: () => Name[];
         pagination={{
           current: currentPage,
           pageSize: pageSize,
-          onChange: (page, pageSize) => {
+          onChange: (page, newPageSize) => {
             setCurrentPage(page);
-            pageSize && setPageSize(pageSize);
+            if (newPageSize !== pageSize) {
+              setPageSize(pageSize);
+              setCurrentPage(1);
+              const tr = document.querySelector('tr[data-row-key]');
+              //@ts-ignore
+              tr.focus();
+            }
           },
         }}
         rowClassName={(record, index) => 'row-' + index}

--- a/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
+++ b/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
@@ -19,7 +19,7 @@ export const NamesTable = ({ getNames, loadingNames }: { getNames: () => Name[];
   const [expandedRowKeys, setExpandedRowKeys] = useState<readonly React.ReactText[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
-  const [focusedRow, setFocusedRow] = useState(1);
+  const [focusedRow, setFocusedRow] = useState(0);
 
   const dataSource = getNames().map((item, i) => {
     return {
@@ -67,6 +67,8 @@ export const NamesTable = ({ getNames, loadingNames }: { getNames: () => Name[];
     },
     [currentPage, dataSource, focusedRow, setFocusedRow]
   );
+
+  console.log(focusedRow);
 
   const components = {
     body: { row: CustomRow },

--- a/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
+++ b/src/ui/views/Names/Tabs/NamedAddrsTable.tsx
@@ -53,7 +53,12 @@ export const NamesTable = ({ getNames, loadingNames }: { getNames: () => Name[];
       currentPage > 1 && setCurrentPage(currentPage - 1);
       const tr = document.querySelector('tr[data-row-key]');
       const siblings = getSiblings(tr);
-      siblings[focusedRow].focus();
+      if (currentPage === 1) {
+        //@ts-ignore
+        tr.focus();
+      } else {
+        siblings[focusedRow].focus();
+      }
     },
     [currentPage, dataSource, focusedRow, setFocusedRow]
   );


### PR DESCRIPTION
Addresses and fixes the following issues:

> Two very small issues that can be fixed later:
> 
> 1. Hit end key twice, see toggle between last and second last row
> 2. Go to page four or five. Scroll down four or five lines. Hit previous page key. It properly stays on the `nth` line as it should as it scrolls through pages. The first time it gets to the first page, it should stay on the `nth` line (as it does). If user hits previous page again, while on first page, it should go to first row of first page to signal no more movement is possible.
> 
> Do those two more things and I will close this.

