### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,7 @@ yarn
 yarn develop
 ```
 
-Now, the application should be running at `localhost:1234`:
-
-
-<img src="./public/screen_shot.png" />
+Now, the application should be running at `localhost:1234`.
 
 ## NPM Scripts
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ There are many, many options to use TrueBlocks. Here are a few:
 
 - Using the command line, get tab-seperated list of every **log** that an address appears in:
 
-  - `> chifra export --logs 0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359 --fmt txt`
+  - `chifra export --logs 0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359 --fmt txt`
 
 - Get JSON details of every **trace** in which a specific address appears:
 
@@ -157,7 +157,7 @@ There are many, many options to use TrueBlocks. Here are a few:
 
 - From the command line, get tab-seperated text of every **balance change in US dollars** for an address:
 
-  - `> chifra export --balances --deltas 0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359 --dollars`
+  - `chifra export --balances --deltas 0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359 --dollars`
 
 - Get balance of DAI for an address at current block on command line:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![React](https://img.shields.io/badge/React-node.js-purple.svg)](https://reactjs.org/)
 [![Twitter](https://img.shields.io/twitter/follow/espadrine.svg?style=social&label=Twitter)](https://twitter.com/quickblocks?lang=es)
 
-TrueBlocks lets you explore the Ethereum blockchain in a fully-local and therefore fully-private way. This repo provides a frontend (this repo) application for the backend, [TrueBlocks core](https://github.com/TrueBlocks/trueblocks-core).
+TrueBlocks lets you explore the Ethereum blockchain in a fully-local and therefore fully-private way. This repo provides a frontend application for the backend, [TrueBlocks core](https://github.com/TrueBlocks/trueblocks-core).
 
 ## Prerequisites
 
@@ -137,7 +137,7 @@ There are many, many options to use TrueBlocks. Here are a few:
 
   - `curl http://localhost/list?address=0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359`
 
-- Get full details of every **transaction** for specific address to CSV:
+- Get full details of every **transaction** for a specific address to CSV:
 
   - `curl http://localhost/export?address=0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359&fmt=csv`
 
@@ -155,7 +155,7 @@ There are many, many options to use TrueBlocks. Here are a few:
   - `chifra names 0x6b175474e89094c44da98b954eedeac495271d0f` // DAI
   - `curl http://localhost/names?0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359` // TrueBlocks Tip Jar
 
-- From the command line, get tab-seperated text of every **balance change in US dollars** for an addresses:
+- From the command line, get tab-seperated text of every **balance change in US dollars** for an address:
 
   - `> chifra export --balances --deltas 0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359 --dollars`
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![React](https://img.shields.io/badge/React-node.js-purple.svg)](https://reactjs.org/)
 [![Twitter](https://img.shields.io/twitter/follow/espadrine.svg?style=social&label=Twitter)](https://twitter.com/quickblocks?lang=es)
 
-TrueBlocks lets you explore the Ethereum blockchain in a fully-local and therefore fully-private way. This repo provides a frontend (this repo) application for the backend, [https://github.com/TrueBlocks/trueblocks-core](TrueBlocks core).
+TrueBlocks lets you explore the Ethereum blockchain in a fully-local and therefore fully-private way. This repo provides a frontend (this repo) application for the backend, [TrueBlocks core](https://github.com/TrueBlocks/trueblocks-core).
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Image Logo](https://avatars1.githubusercontent.com/u/19167586?s=200&v=4)
 
 [![Website](https://img.shields.io/badge/Website-quickblocks.io-brightgreen.svg)](https://quickblocks.io/)
-[![TrueBlocks](https://img.shields.io/badge/Trueblocks-explorer-blue.svg)](https://github.com/Great-Hill-Corporation/trueblocks-explorer)
+[![TrueBlocks](https://img.shields.io/badge/Trueblocks-explorer-blue.svg)](https://github.com/TrueBlocks/trueblocks-explorer)
 [![React](https://img.shields.io/badge/React-node.js-purple.svg)](https://reactjs.org/)
 [![Twitter](https://img.shields.io/twitter/follow/espadrine.svg?style=social&label=Twitter)](https://twitter.com/quickblocks?lang=es)
 
@@ -52,7 +52,7 @@ Now, the application should be running at `localhost:1234`:
 
 ## Requirements
 
-- **Note:** In order for the TrueBlocks to work, you must have access to an Ethereum node with **--tracing** enabled. An excellent choice is Turbo-Geth (now called XXX). TrueBlocks defaults to using Parity at the RPC endpoint http://localhost:8545, but you may use any node supporting tracing and any endpoint (Infura, Quiknodes, for example). Performance will be _greatly reduced_ if you use a remote server. A good solution to this problem is to run a node on the [dAppNode](https://dappnode.io/) or [Ava.do](https://ava.do/) platforms and use [the TrueBlocks docker image](http://github.com/Great-Hill-Corporation/trueblocks-docker).
+- **Note:** In order for the TrueBlocks to work, you must have access to an Ethereum node with `--tracing` enabled. An excellent choice is Turbo-Geth (now called XXX). TrueBlocks defaults to using Parity at the RPC endpoint http://localhost:8545, but you may use any node supporting tracing and any endpoint (Infura, Quiknodes, for example). Performance will be _greatly reduced_ if you use a remote server. A good solution to this problem is to run a node on the [dAppNode](https://dappnode.io/) or [Ava.do](https://ava.do/) platforms and use [the TrueBlocks docker image](http://github.com/TrueBlocks/trueblocks-docker).
 
 ## Getting Data on the Command Line
 
@@ -189,7 +189,7 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduc
 - **Thomas Jay Rush** - [tjayrush](https://github.com/tjayrush)
 - **Ed Mazurek** - [wildmolasses](https://github.com/wildmolasses)
 
-See also the list of [contributors](https://github.com/Great-Hill-Corporation/trueblocks-docker/contributors) who participated in this project.
+See also the list of [contributors](https://github.com/TrueBlocks/trueblocks-explorer/contributors) who participated in this project.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Prior to proceeding, you must [install the TrueBlocks Core](http://docs.truebloc
 
 Assuming you have the TrueBlocks core properly installed and can successfully run the following command:
 
-```[shell]
-> chifra --version
+```shell
+chifra --version
 ```
 
 Then, you need to serve the index on your local machine:
@@ -31,7 +31,7 @@ chifra serve
 
 From your development folder:
 
-```[shell]
+```shell
 git clone git@github.com:TrueBlocks/trueblocks-explorer.git
 cd trueblocks-explorer
 cp .env.example .env
@@ -56,15 +56,15 @@ Now, the application should be running at `localhost:1234`:
 
 ## Getting Data on the Command Line
 
-Assuming TrueBlocks is installed correctly, and that you have a node endpoint, and that the tools are in your \$PATH, you should be able to run the following command at a command prompt:
+Assuming TrueBlocks is installed correctly, and that you have a node endpoint, and that the tools are in your `$PATH`, you should be able to run the following command at a command prompt:
 
-```
-> chifra blocks 100
+```shell
+chifra blocks 100
 ```
 
 and get valid data from your node:
 
-```
+```json
 {
   "data": [
     {
@@ -86,14 +86,14 @@ and get valid data from your node:
 
 If that works, try this command:
 
-```
-> chifra blocks 0-latest:10000
+```shell
+chifra blocks 0-latest:10000
 ```
 
 Which exports every 10,000th block in the chain from first to last. Or, try this command:
 
-```
-> chifra blocks --uniq_tx 4001001
+```shell
+chifra blocks --uniq_tx 4001001
 ```
 
 Which shows every address that appears anywhere in block 4,001,001. There are literally hundreds of other options to `chifra` and the other tools. See the documentation.
@@ -102,8 +102,8 @@ Which shows every address that appears anywhere in block 4,001,001. There are li
 
 The TrueBlocks Explorer uses an API to access data provided (that is ultimately provided by `chifra`). Assuming everything is installed correctly and you've started the API server, you should be able to get the same data from the API:
 
-```
-> curl "http://localhost:8080/blocks?blocks=4001001&uniq_tx"
+```shell
+curl "http://localhost:8080/blocks?blocks=4001001&uniq_tx"
 ```
 
 which returns the same as the preceding `chifra blocks --uniq_tx` command.
@@ -118,16 +118,16 @@ However, you can change this by adding the options `&fmt=txt` or `&fmt=csv` to y
 
 For documentation on the API, you may do this:
 
-```
-> open "http://localhost:8090"
+```shell
+open "http://localhost:8090"
 ```
 
 ## Scraping the Chain
 
 To begin the process of creating the address index, enter this command in a seperate window or `tmux` session. You will need to keep this process running continually to keep the index fresh.
 
-```
-> chifra scrape
+```shell
+chifra scrape
 ```
 
 - **Note:** This requires a _--tracing node_ to produce a full list of appearances. It will work (with some configuration changes) on non-tracing nodes, but many of the appearances will not be included. Note also, this takes a loooong time. Depending on your setup at least 2-3 days (local node endpoint) or significantly longer (remote, rate-limited RPC endpoints).

--- a/README.md
+++ b/README.md
@@ -177,10 +177,6 @@ Yes - Parity delivers the necessary articulated traces so that TrueBlocks can bu
 
 ### More coming soon...
 
-## Contributing
-
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
-
 ## Authors
 
 - **Thomas Jay Rush** - [tjayrush](https://github.com/tjayrush)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Now, the application should be running at `localhost:1234`.
 
 ## Requirements
 
-- **Note:** In order for the TrueBlocks to work, you must have access to an Ethereum node with `--tracing` enabled. An excellent choice is Turbo-Geth (now called XXX). TrueBlocks defaults to using Parity at the RPC endpoint http://localhost:8545, but you may use any node supporting tracing and any endpoint (Infura, Quiknodes, for example). Performance will be _greatly reduced_ if you use a remote server. A good solution to this problem is to run a node on the [dAppNode](https://dappnode.io/) or [Ava.do](https://ava.do/) platforms and use [the TrueBlocks docker image](http://github.com/TrueBlocks/trueblocks-docker).
+- **Note:** In order for the TrueBlocks to work, you must have access to an Ethereum node with `--tracing` enabled. An excellent choice is [Erigon](https://github.com/ledgerwatch/erigon) (previously called Turbo-Geth). TrueBlocks defaults to using Parity at the RPC endpoint http://localhost:8545, but you may use any node supporting tracing and any endpoint (Infura, Quiknodes, for example). Performance will be _greatly reduced_ if you use a remote server. A good solution to this problem is to run a node on the [dAppNode](https://dappnode.io/) or [Ava.do](https://ava.do/) platforms and use [the TrueBlocks docker image](http://github.com/TrueBlocks/trueblocks-docker).
 
 ## Getting Data on the Command Line
 


### PR DESCRIPTION
A couple of drive-by improvements:

* Fix broken or outdated links (c2c2756)

* Fix incorrect Markdown link (7d3b693)

* Fix Markdown code blocks (961c1b5)

    This gives proper syntax highlighting on Github and other editors
    who support Github-flavored Markdown.


* Remove broken screenshot (9be1547)

    This link was introduced in 4ac9aa583051fb7b19c2372c08d6cc9b66a96075,
    but the actual screenshot was deleted in e59f802c20b6aa05aa2ccf6e4b1c0612daeaa16e.

    THe UI looks pretty different now so I prefered removing than reintroducing.


* Remove reference to nonexistent CONTRIBUTING.md (a6e7744)

    This seems to be incorrectly copied boilerplate.


* Fix reference to Erigon/Turbo-Geth (293a67f)

* Fix misc. typos (adfd75f)