### PR TITLE
Fixed: cannot switch to History by clicking the link

### DIFF
--- a/src/ui/components/BaseView/index.tsx
+++ b/src/ui/components/BaseView/index.tsx
@@ -1,6 +1,6 @@
 import { PageHeader, Tabs } from 'antd';
-import React, { ReactNode, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import React, { ReactNode, useEffect, useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 
 const { TabPane } = Tabs;
 
@@ -22,12 +22,21 @@ export interface ViewParams {
 
 export const BaseView = ({ cookieName, tabs, extraContent, title = '', position = 'top' }: ViewParams) => {
   const history = useHistory();
-  const [lastVisited] = useState(localStorage.getItem(cookieName) || tabs[0].location);
+  const { pathname } = useLocation();
+  const [lastVisited, setLastVisited] = useState(localStorage.getItem(cookieName) || tabs[0].location);
 
   const onTabChange = (key: string) => {
     localStorage.setItem(cookieName, key);
     history.push(key);
   };
+
+  // needed for <Link> to work
+  useEffect(() => {
+    if (!tabs.find((tab) => tab.location === pathname)) return;
+
+    setLastVisited(pathname);
+    onTabChange(pathname);
+  }, [pathname]);
 
   const titleComponent = title.length === 0 ? <></> : <PageHeader style={{ padding: '0px' }} title={title} />;
   return (
@@ -37,6 +46,7 @@ export const BaseView = ({ cookieName, tabs, extraContent, title = '', position 
         tabBarExtraContent={extraContent}
         tabPosition={position}
         defaultActiveKey={lastVisited}
+        activeKey={lastVisited}
         onChange={(key) => onTabChange(key)}>
         {tabs.map((tab) => (
           <TabPane tab={tab.name} key={tab.location} disabled={tab.disabled}>


### PR DESCRIPTION
This particular issue is fixed, but I will try to clean up saving the last visited tab after/while refactoring Dashboard tomorrow