### PR TITLE
Added rule for sorting imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,8 +39,8 @@ module.exports = {
   },
   plugins: [
     'react',
-    // 'react-hooks',
     '@typescript-eslint',
+    'simple-import-sort'
   ],
   rules: {
     'indent': ['error', 2, { SwitchCase: 1 }],
@@ -56,5 +56,24 @@ module.exports = {
     'no-unused-vars': 'off',
     '@typescript-eslint/no-shadow': 'error',
     '@typescript-eslint/no-unused-vars': 'error',
+    'simple-import-sort/imports': ['error', {
+      groups: [
+        // React
+        ['^react'],
+        // Side effect imports.
+        ['^\\u0000'],
+        // NPM modules starting with '@'
+        ['^@(?!components|hooks|modules\\b)\\w', '^\\w'],
+        // Anything else
+        ['^'],
+        // Our aliases
+        ['^@components', '^@hooks', '^@modules'],
+        // Relative imports
+        ['^\\.'],
+        // Styles
+        ['^.+\\.s?css$']
+      ]
+    }],
+    'simple-import-sort/exports': 'error'
   },
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "file-loader": "^6.2.0",
     "fork-ts-checker-webpack-plugin": "^6.1.1",
     "html-webpack-plugin": "^5.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4807,6 +4807,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-simple-import-sort@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "eslint-plugin-simple-import-sort@npm:7.0.0"
+  peerDependencies:
+    eslint: ">=5.0.0"
+  checksum: 51fc6b675220681fd88e8fb7c0b9ff9b3b38e2c060999c72da7b0dee469cfe3fdbe1284374f2ade5015ee93d4d59eaf2d29c6185d4131b30aa057d9c9dec9483
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:5.1.1, eslint-scope@npm:^5.1.1":
   version: 5.1.1
   resolution: "eslint-scope@npm:5.1.1"
@@ -12647,6 +12656,7 @@ resolve@^2.0.0-next.3:
     eslint-plugin-jsx-a11y: ^6.4.1
     eslint-plugin-react: ^7.22.0
     eslint-plugin-react-hooks: ^4.2.0
+    eslint-plugin-simple-import-sort: ^7.0.0
     file-loader: ^6.2.0
     filesize: ^6.3.0
     fork-ts-checker-webpack-plugin: ^6.1.1


### PR DESCRIPTION
This sorts imports, example:

From:
```
import { BaseView } from '@components/BaseView';
import { Result, toFailedResult, toSuccessfulData } from '@hooks/useCommand';
import { runCommand } from '@modules/core';
import { createErrorNotification } from '@modules/error_notification';
import {
  AssetHistory,
  AssetHistoryArray,
  Reconciliation,
  Transaction,
  createEmptyAccountname,
} from '@modules/types';
import { either as Either } from 'fp-ts';
import { pipe } from 'fp-ts/lib/function';
import Mousetrap from 'mousetrap';
import React, {
  useEffect, useMemo, useState,
} from 'react';
import {
  DashboardAccountsLocation,
  DashboardCollectionsLocation,
  DashboardLocation,
  DashboardMonitorsLocation,
} from '../../Routes';
import { useGlobalNames, useGlobalState } from '../../State';
import { Collections } from './Tabs/Collections';
import { DetailsView } from './Tabs/Details';
import { Monitors } from './Tabs/Monitors';
```
To:
```
import React, {
  useEffect, useMemo, useState,
} from 'react';

import { either as Either } from 'fp-ts';
import { pipe } from 'fp-ts/lib/function';
import Mousetrap from 'mousetrap';

import { BaseView } from '@components/BaseView';
import { Result, toFailedResult, toSuccessfulData } from '@hooks/useCommand';
import { runCommand } from '@modules/core';
import { createErrorNotification } from '@modules/error_notification';
import {
  AssetHistory,
  AssetHistoryArray,
  createEmptyAccountname,
  Reconciliation,
  Transaction,
} from '@modules/types';

import {
  DashboardAccountsLocation,
  DashboardCollectionsLocation,
  DashboardLocation,
  DashboardMonitorsLocation,
} from '../../Routes';
import { useGlobalNames, useGlobalState } from '../../State';
import { Collections } from './Tabs/Collections';
import { DetailsView } from './Tabs/Details';
import { Monitors } from './Tabs/Monitors';
```