### PR TITLE
Fixed SDK generator for DELETE paths

### DIFF
--- a/src/sdk/generated_ts/paths/monitors.ts
+++ b/src/sdk/generated_ts/paths/monitors.ts
@@ -36,7 +36,7 @@ export function deleteMonitors(
   },
   options?: RequestInit,
 ) {
-  return ApiCallers.fetch<Monitor[]>(
+  return ApiCallers.fetch<never>(
     {
       endpoint: '/monitors', method: 'delete', parameters, options,
     },

--- a/src/sdk/src/code_generator.ts
+++ b/src/sdk/src/code_generator.ts
@@ -7,8 +7,7 @@ import * as helpers from './helpers';
 import * as pathFile from './path_file';
 import * as typeFile from './type_file';
 
-// const openApiUrl = 'https://trueblocks.io/api/openapi.yaml';
-const openApiUrl = '../trueblocks-core/docs/content/api/openapi.yaml';
+const openApiUrl = process.env.URL || 'https://trueblocks.io/api/openapi.yaml';
 
 /**
  * Downloads OpenAPI file and returns it parsed

--- a/src/sdk/src/type.ts
+++ b/src/sdk/src/type.ts
@@ -29,6 +29,7 @@ export function isNotBuiltinType(model: TypeModel): boolean {
   const { name } = model;
 
   return ![
+    'never',
     'string',
     'number',
     'boolean',
@@ -194,7 +195,7 @@ export function getResponseBodyType(path: OpenAPIV3.OperationObject) {
 
   if (!content) {
     // Some responses don't have Body (e.g. DELETE, but this can change)
-    return [{ name: 'undefined', isRequired: true, isArray: false }];
+    return [{ name: 'never', isRequired: true, isArray: false }];
   }
 
   // Right now we only support JSON responses


### PR DESCRIPTION
- Added environment variable (`URL`) to override default OpenAPI URL
- For requests that never return a body, switched from `undefined` to `never`
- Disabled global parameters but `chain` for DELETE paths