### PR TITLE
Multi chain 11 right tab layout

### DIFF
--- a/src/ui/Routes.tsx
+++ b/src/ui/Routes.tsx
@@ -197,10 +197,15 @@ Mousetrap.bind('s k', () => {
 
 export const Routes = () => (
   <Switch>
-    {routes.map((props) => (
-      // eslint-disable-next-line
-      <Route key={props.path[0]} path={props.path} component={props.component} exact={props.exact} />
-    ))}
+    {routes.map((props, index) => {
+      // eslint-disable-next-line react/prop-types
+      const key = props.path[0] + index;
+
+      return (
+        // eslint-disable-next-line react/prop-types
+        <Route key={key} path={props.path} component={props.component} exact={props.exact} />
+      );
+    })}
     <DashboardView />
   </Switch>
 );

--- a/src/ui/components/Table/BaseTable.tsx
+++ b/src/ui/components/Table/BaseTable.tsx
@@ -35,7 +35,7 @@ export const BaseTable = ({
   const [curRow, setCurRow] = useState(Number(sessionStorage.getItem(`curRow${name}`)) || 0);
   const [curPage, setCurPage] = useState(Number(sessionStorage.getItem(`curPage${name}`)) || 1);
   const [pageSize, setPageSize] = useState(defPageSize);
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [expandedRow, setExpandedRow] = useState(-1);
   const [keyedData, setKeyedData] = useState([{ key: 0 }]);
   const tableRef = useRef<HTMLTableElement>(document.createElement('table'));
 
@@ -58,7 +58,11 @@ export const BaseTable = ({
   Mousetrap.bind('home', (event) => setRowAndHandleScroll(event, 0));
   Mousetrap.bind('end', (event) => setRowAndHandleScroll(event, dataSource.length - 1));
   Mousetrap.bind('enter', () => {
-    setIsExpanded(!isExpanded);
+    setExpandedRow((currentValue) => {
+      if (currentValue === curRow) return -1; // disable
+
+      return curRow;
+    });
   });
 
   useEffect(() => {
@@ -117,6 +121,7 @@ export const BaseTable = ({
         dataSource={keyedData}
         expandable={{
           expandedRowRender,
+          expandedRowKeys: [expandedRow],
         }}
         pagination={{
           onChange: (page, newPageSize) => {
@@ -133,5 +138,3 @@ export const BaseTable = ({
     </div>
   );
 };
-
-// TODO(tjayrush): We used to be able to press enter to open a record's details

--- a/src/ui/components/Table/BaseTable.tsx
+++ b/src/ui/components/Table/BaseTable.tsx
@@ -18,20 +18,20 @@ export const BaseTable = ({
   loading,
   extraData,
   expandRender = undefined,
-  siderRender = undefined,
   defPageSize = 7,
   name = '',
+  onSelectionChange = () => { },
 }: {
   dataSource: JsonResponse;
   columns: ColumnsType<any>;
   loading: boolean;
   extraData?: string;
   expandRender?: (row: any) => JSX.Element;
-  siderRender?: (record: any) => JSX.Element;
   defPageSize?: number;
   name?: string;
+  onSelectionChange?: (row: unknown) => void,
 }) => {
-  const [displayedRow, setDisplayedRow] = useState(dataSource ? dataSource[0] : {});
+  const [, setDisplayedRow] = useState(dataSource ? dataSource[0] : {});
   const [curRow, setCurRow] = useState(Number(sessionStorage.getItem(`curRow${name}`)) || 0);
   const [curPage, setCurPage] = useState(Number(sessionStorage.getItem(`curPage${name}`)) || 1);
   const [pageSize, setPageSize] = useState(defPageSize);
@@ -78,7 +78,8 @@ export const BaseTable = ({
 
   useEffect(() => {
     setDisplayedRow(keyedData[curRow]);
-  }, [curRow, keyedData]);
+    onSelectionChange(keyedData[curRow]);
+  }, [curRow, keyedData, onSelectionChange]);
 
   const setRowAndHandleScroll = useCallback((event: KeyboardEvent, rowNumber: number) => {
     const { row } = setRowNumber(rowNumber);
@@ -97,13 +98,12 @@ export const BaseTable = ({
     Mousetrap.unbind(['up', 'down', 'pageup', 'pagedown', 'home', 'end', 'enter']);
   }, []);
 
-  const gridStyle = siderRender ? { display: 'grid', gridTemplateColumns: '225fr 1fr 120fr' } : {};
   const expandedRowRender = expandRender !== undefined
     ? expandRender
     : (row: any) => <pre>{JSON.stringify(row, null, 2)}</pre>;
 
   return (
-    <div ref={tableRef} style={gridStyle}>
+    <div ref={tableRef}>
       <Table
         onRow={(record) => ({
           onClick: () => {
@@ -130,8 +130,6 @@ export const BaseTable = ({
           pageSizeOptions: ['5', '10', '20', '50', '100'],
         }}
       />
-      <div />
-      {siderRender ? siderRender(displayedRow) : <></>}
     </div>
   );
 };

--- a/src/ui/views/Dashboard/Tabs/Details/SubTabs/History.tsx
+++ b/src/ui/views/Dashboard/Tabs/Details/SubTabs/History.tsx
@@ -1,8 +1,10 @@
 import React, {
+  useCallback,
   useEffect, useMemo, useState,
 } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
+import { Col, Row } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 
 import { BaseView } from '@components/BaseView';
@@ -43,6 +45,7 @@ export const History = ({ params }: { params: AccountViewParams }) => {
   const [assetToFilterBy, setAssetToFilterBy] = useState('');
   const [eventToFilterBy, setEventToFilterBy] = useState('');
   const [functionToFilterBy, setFunctionToFilterBy] = useState('');
+  const [selectedItem, setSelectedItem] = useState<typeof theData>();
   const searchParams = useSearchParams();
 
   const assetNameToDisplay = useMemo(() => {
@@ -133,23 +136,28 @@ export const History = ({ params }: { params: AccountViewParams }) => {
     </FilterButton>
   );
 
-  const siderRender = (record: TransactionModel) => (
-    <AccountHistorySider record={record} params={params} />
-  );
+  const onSelectionChange = useCallback((item) => setSelectedItem(item), []);
 
   return (
     <div>
-      {activeAssetFilter}
-      {activeEventFilter}
-      {activeFunctionFilter}
-      <BaseTable
-        dataSource={filteredData}
-        columns={transactionSchema}
-        loading={loading}
-        extraData={currentAddress}
-        siderRender={siderRender}
-        name='history'
-      />
+      <Row wrap={false} gutter={16}>
+        <Col span={16}>
+          {activeAssetFilter}
+          {activeEventFilter}
+          {activeFunctionFilter}
+          <BaseTable
+            dataSource={filteredData}
+            columns={transactionSchema}
+            loading={loading}
+            extraData={currentAddress}
+            name='history'
+            onSelectionChange={onSelectionChange}
+          />
+        </Col>
+        <Col flex={8}>
+          <AccountHistorySider record={selectedItem} params={params} />
+        </Col>
+      </Row>
     </div>
   );
 };

--- a/src/ui/views/Dashboard/Tabs/Details/SubTabs/History.tsx
+++ b/src/ui/views/Dashboard/Tabs/Details/SubTabs/History.tsx
@@ -141,7 +141,7 @@ export const History = ({ params }: { params: AccountViewParams }) => {
   return (
     <div>
       <Row wrap={false} gutter={16}>
-        <Col span={16}>
+        <Col flex='3'>
           {activeAssetFilter}
           {activeEventFilter}
           {activeFunctionFilter}
@@ -154,8 +154,11 @@ export const History = ({ params }: { params: AccountViewParams }) => {
             onSelectionChange={onSelectionChange}
           />
         </Col>
-        <Col flex={8}>
-          <AccountHistorySider record={selectedItem} params={params} />
+        <Col flex='2'>
+          {/* this minWidth: 0 stops children from overflowing flex parent */}
+          <div style={{ minWidth: 0 }}>
+            <AccountHistorySider record={selectedItem} params={params} />
+          </div>
         </Col>
       </Row>
     </div>

--- a/src/ui/views/Dashboard/Tabs/Details/SubTabs/HistoryEvents.tsx
+++ b/src/ui/views/Dashboard/Tabs/Details/SubTabs/HistoryEvents.tsx
@@ -38,14 +38,15 @@ export const HistoryEvents = ({ record }: { record: Transaction }) => {
 
   const relevants = record.receipt?.logs?.map((log, index) => {
     const hasAddress = Boolean(log.address);
-    if (!hasAddress) return <></>;
-    return <RelevantLog log={log} index={log.logIndex} />;
+    if (!hasAddress) return null;
+    return <RelevantLog key={log.logIndex} log={log} index={log.logIndex} />;
   });
 
   const irrelevants = record.receipt?.logs?.map((log, index) => {
     const hasAddress = Boolean(log.address);
-    if (hasAddress) return <></>;
-    return <IrrelevantLog index={index} />;
+    if (hasAddress) return null;
+    if (!Object.keys(log).length) return null;
+    return <IrrelevantLog key={log.logIndex} index={index} />;
   });
 
   return (

--- a/src/ui/views/Dashboard/Tabs/Details/SubTabs/HistoryEvents.tsx
+++ b/src/ui/views/Dashboard/Tabs/Details/SubTabs/HistoryEvents.tsx
@@ -56,7 +56,11 @@ export const HistoryEvents = ({ record }: { record: Transaction }) => {
           className={styles.card}
           headStyle={headerStyle}
           hoverable
-          title={title}
+          title={(
+            <span style={{ whiteSpace: 'break-spaces' }}>
+              {title}
+            </span>
+          )}
         >
           {relevants}
           {irrelevants}

--- a/src/ui/views/Dashboard/Tabs/Details/SubTabs/HistoryEvents.tsx
+++ b/src/ui/views/Dashboard/Tabs/Details/SubTabs/HistoryEvents.tsx
@@ -67,20 +67,24 @@ export const HistoryEvents = ({ record }: { record: Transaction }) => {
 };
 
 //-----------------------------------------------------------------
-const RelevantLog = ({ log, index } : {log: Log, index: number}) => ((
-  <pre key={log.logIndex}>
-    <b>
-      <u>
-        log
-        {' '}
-        {index}
-        :
-      </u>
-    </b>
-    <br />
-    {JSON.stringify(log, null, 2)}
-  </pre>
-));
+const RelevantLog = ({ log, index }: { log: Log, index: number }) => {
+  const styles = useAcctStyles();
+
+  return (
+    <pre key={log.logIndex} className={styles.pre}>
+      <b>
+        <u>
+          log
+          {' '}
+          {index}
+          :
+        </u>
+      </b>
+      <br />
+      {JSON.stringify(log, null, 2)}
+    </pre>
+  );
+};
 
 //-----------------------------------------------------------------
 const IrrelevantLog = ({ index } : {index: number}) => {

--- a/src/ui/views/Dashboard/Tabs/Details/SubTabs/HistoryRecons.tsx
+++ b/src/ui/views/Dashboard/Tabs/Details/SubTabs/HistoryRecons.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
 import { Reconciliation, Transaction } from '@sdk';
-import { Card } from 'antd';
+import { useGlobalState } from '@state';
+import { Card, Space, Tag } from 'antd';
 
 import {
   double, priceReconciliation,
 } from '@modules/types';
 
-import { useGlobalState } from '../../../../../State';
 import { AccountViewParams } from '../../../Dashboard';
 import { useAcctStyles } from '..';
 
@@ -52,29 +52,52 @@ const oneStatement = (
     hoverable
     title={statementHeader(statement, details, setShowDetails)}
   >
-    {statementBody(statement, details, styles)}
+    <Space size='middle' direction='vertical' style={{ width: '100%' }}>
+      <Space>
+        <div>
+          Spot price:
+          {' '}
+          USD
+          {' '}
+          <strong>
+            {statement.spotPrice}
+          </strong>
+          {' '}
+
+          (
+          {statement.priceSource}
+          )
+        </div>
+        {statement.reconciliationType
+          ? (
+            <Tag>
+              {statement.reconciliationType}
+            </Tag>
+          )
+          : null}
+      </Space>
+      {statementBody(statement, details, styles)}
+    </Space>
   </Card>
 );
 
 //-----------------------------------------------------------------
-const statementHeader = (statement: Reconciliation, details: boolean, setShowDetails: any) => (
-  <div style={{ display: 'grid', gridTemplateColumns: '20fr 1fr', textAlign: 'start' }}>
-    <div>
-      {`${statement.assetSymbol} reconciliation`}
-      {' '}
-      [
-      {statement.reconciliationType}
-      ] (spotPrice:
-      {statement.spotPrice}
-      -
-      {statement.priceSource}
-      )
+const statementHeader = (statement: Reconciliation, details: boolean, setShowDetails: any) => {
+  const title = `${statement.assetSymbol} reconciliation`;
+  return (
+    <div style={{
+      display: 'grid', gridTemplateColumns: '20fr 1fr', textAlign: 'start', alignItems: 'center',
+    }}
+    >
+      <div style={{ textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden' }} title={title}>
+        {title}
+      </div>
+      <button style={{ outline: 'none' }} type='button' onClick={() => setShowDetails(!details)}>
+        {details ? '-' : '+'}
+      </button>
     </div>
-    <button style={{ outline: 'none' }} type='button' onClick={() => setShowDetails(!details)}>
-      {details ? '-' : '+'}
-    </button>
-  </div>
-);
+  );
+};
 
 //-----------------------------------------------------------------
 const statementBody = (statement: Reconciliation, details: boolean, styles: any) => {
@@ -106,7 +129,7 @@ const statementBody = (statement: Reconciliation, details: boolean, styles: any)
     someString === '' ? 0.0 : parseFloat(someString)));
 
   return (
-    <table>
+    <table style={{ width: '100%', tableLayout: 'fixed' }}>
       <tbody>
         <HeaderRow />
         {BodyRow(rowStyle, 'begBal', details, 0, 0, ...toNumberArguments(statement.begBal, statement.begBalDiff))}
@@ -153,25 +176,23 @@ const BodyRow = (
 ) => {
   const isShowZero = name === 'begBal' || name === 'endBal' || name === 'totalNet';
   const isBal = name === 'begBal' || name === 'endBal';
-  // TODO: Comment by @dszlachta
-  // TODO: If I remove Number here, the test fails and empty rows show up on Reconciliation component
-  if (Number(valueIn) === 0
-    && Number(valueOut) === 0
-    && Number(balance) === 0
-    && Number(diffIn) === 0
+
+  if (valueIn === 0
+    && valueOut === 0
+    && balance === 0
+    && diffIn === 0
     && !isShowZero && !details) { return <></>; }
 
-  const plain = { color: 'black', width: '100px' };
-  const green = { color: 'green', width: '100px' };
-  const red = { color: 'red', width: '100px' };
+  const plain = { color: 'black' };
+  const green = { color: 'green' };
+  const red = { color: 'red' };
   const balStyle = balance < 0 ? red : green;
 
   return (
     <tr>
-      <td className={style} style={plain}>
+      <td className={style} style={{ textOverflow: 'ellipsis', ...plain }} title={name}>
         {name}
       </td>
-      <td className={style} style={{ width: '20px' }} />
       <td className={style} style={green}>
         {clip2(valueIn)}
       </td>
@@ -193,7 +214,7 @@ const DetailRow = (style: string, name: string, value: double | string) => {
   const isErr: boolean = name?.includes('Diff') && value !== 0;
   const disp = (
     <tr>
-      <td className={style} style={{ width: '100px' }} colSpan={2}>
+      <td className={style} colSpan={2}>
         {name}
       </td>
       <td
@@ -203,7 +224,6 @@ const DetailRow = (style: string, name: string, value: double | string) => {
       >
         {typeof value === 'string' ? value : clip2(value)}
       </td>
-      <td className={style} />
     </tr>
   );
   return disp;
@@ -212,7 +232,7 @@ const DetailRow = (style: string, name: string, value: double | string) => {
 //-----------------------------------------------------------------
 const DividerRow = (style: string) => (
   <tr>
-    <td className={style} colSpan={6}>
+    <td className={style} colSpan={5}>
       <hr />
     </td>
   </tr>
@@ -223,12 +243,11 @@ const HeaderRow = () => {
   const styles = useAcctStyles();
   return (
     <tr>
-      <td className={styles.tableHead} style={{ width: '100px' }} />
-      <td className={styles.tableHead} style={{ width: '20px' }} />
-      <td className={styles.tableHead} style={{ width: '100px' }}>income</td>
-      <td className={styles.tableHead} style={{ width: '100px' }}>outflow</td>
-      <td className={styles.tableHead} style={{ width: '100px' }}>balance</td>
-      <td className={styles.tableHead} style={{ width: '100px' }}>diff</td>
+      <td className={styles.tableHead} style={{ paddingRight: '20px' }} />
+      <td className={styles.tableHead} style={{ }}>income</td>
+      <td className={styles.tableHead} style={{ }}>outflow</td>
+      <td className={styles.tableHead} style={{ }}>balance</td>
+      <td className={styles.tableHead} style={{ }}>diff</td>
     </tr>
   );
 };

--- a/src/ui/views/Dashboard/Tabs/Details/components/FunctionDisplay.tsx
+++ b/src/ui/views/Dashboard/Tabs/Details/components/FunctionDisplay.tsx
@@ -12,6 +12,27 @@ export const FunctionDisplay = ({ func, rawBytes }: { func: Function, rawBytes: 
   let thing = <></>;
   let articulated = <></>;
 
+  const entriesToTableRow = (name: string, object: object) => {
+    let firstKey = '';
+    const rows = Object.entries(object).map(([key, val]) => {
+      firstKey = firstKey || key;
+
+      return (
+        <tr key={`${name}${key}2`}>
+          <td key={`${name}11`} style={{ width: '1%' }} />
+          <td key={`${name}12`} style={{ fontWeight: 'bold', width: '20%' }}>{`${key.substr(0, 25)}:`}</td>
+          <td key={`${name}13`}>{`${val}`}</td>
+        </tr>
+      );
+    });
+
+    return (
+      <React.Fragment key={`${name}${firstKey}`}>
+        {rows}
+      </React.Fragment>
+    );
+  };
+
   // TODO: This hugely horrible thing is temporary -- the real one has to
   // TODO: handle irrelevant parameters and tuple parameters
   if (func) {
@@ -27,17 +48,7 @@ export const FunctionDisplay = ({ func, rawBytes }: { func: Function, rawBytes: 
                   </tr>
                 );
               }
-              return (
-                <>
-                  {Object.entries(value).map(([key, val]) => (
-                    <tr key={`${name}${key}2`}>
-                      <td key={`${name}11`} style={{ width: '1%' }} />
-                      <td key={`${name}12`} style={{ fontWeight: 'bold', width: '20%' }}>{`${key.substr(0, 25)}:`}</td>
-                      <td key={`${name}13`}>{`${val}`}</td>
-                    </tr>
-                  ))}
-                </>
-              );
+              return entriesToTableRow(name, value as object);
             },
           )}
         </tbody>
@@ -45,7 +56,7 @@ export const FunctionDisplay = ({ func, rawBytes }: { func: Function, rawBytes: 
     );
 
     articulated = (
-      <pre style={{ overflowX: 'hidden' }}>
+      <pre className={styles.pre}>
         {thing}
         <br />
       </pre>
@@ -53,7 +64,7 @@ export const FunctionDisplay = ({ func, rawBytes }: { func: Function, rawBytes: 
   }
 
   const bytes = (
-    <pre>
+    <pre className={styles.pre}>
       <div>{rawBytes.slice(0, 10)}</div>
       {rawBytes.replace(rawBytes.slice(0, 10), '')?.match(/.{1,64}/g)?.map((s, index) => (
         <div key={`${s + index}`}>
@@ -80,5 +91,9 @@ const useStyles = createUseStyles({
   header: {
     fontWeight: 'bold',
     textDecoration: 'underline',
+  },
+  pre: {
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
   },
 });

--- a/src/ui/views/Dashboard/Tabs/Details/index.tsx
+++ b/src/ui/views/Dashboard/Tabs/Details/index.tsx
@@ -85,8 +85,6 @@ export const DetailsView = ({ params }: { params: AccountViewParams }) => {
 
 export const useAcctStyles = createUseStyles({
   container: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 28fr 3fr',
   },
   cardHolder: {
     display: 'flex',
@@ -96,8 +94,11 @@ export const useAcctStyles = createUseStyles({
   },
   card: {
     border: '2px solid darkgrey',
-    width: '820px',
     marginBottom: '4px',
+  },
+  pre: {
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
   },
   tableHead: {
     padding: '0px',

--- a/src/ui/views/Dashboard/Tabs/Details/index.tsx
+++ b/src/ui/views/Dashboard/Tabs/Details/index.tsx
@@ -97,6 +97,8 @@ export const useAcctStyles = createUseStyles({
     marginBottom: '4px',
   },
   pre: {
+    width: '100%',
+    lineBreak: 'anywhere',
     whiteSpace: 'pre-wrap',
     wordBreak: 'break-word',
   },

--- a/src/ui/views/Dashboard/Tabs/Details/index.tsx
+++ b/src/ui/views/Dashboard/Tabs/Details/index.tsx
@@ -93,6 +93,7 @@ export const useAcctStyles = createUseStyles({
     padding: '1px',
   },
   card: {
+    width: '100%',
     border: '2px solid darkgrey',
     marginBottom: '4px',
   },


### PR DESCRIPTION
Fixes History tab's "sider" (right hand side tabs):
- sider was moved outside of BaseTable, so the parent component can decide on the layout
- used Antd Grid for layout
- Made sider adjust to the window size (it will take less space in smaller windows, this hurts readability of data, but we can't do anything about it; it will grow a bit if the window is huge)
- Refactored Reconciliations so the data is more visible and the table fits into different sizes of the parent element
- Added line wrapping for `<pre>`s displaying logs and functions. If the window is narrow, then this will break indentation, but: 1. we should display this data in a well-designed way instead of `<pre>` (maybe #232) and 2. as long as we use `<pre>`, we have no control over single lines (so we can't use ellipsis, etc.)
- Fixed table row expansion on `Enter`

Refactored Reconciliations
![Zrzut ekranu 2022-02-18 o 09 05 21](https://user-images.githubusercontent.com/2346536/154670314-e0a43c90-36d2-4e00-a3e6-60169e4f39d7.png)

Line wrap problem in smaller windows:
![Zrzut ekranu 2022-02-18 o 09 04 53](https://user-images.githubusercontent.com/2346536/154670380-ce0049c2-65ba-431c-a26f-2107676ac3e1.png)

