### PR TITLE
Fixed: long strings not being wrapped in DataDisplay

### DIFF
--- a/src/ui/components/DataDisplay/DataDisplay.css
+++ b/src/ui/components/DataDisplay/DataDisplay.css
@@ -24,6 +24,7 @@
 .json-display dl dd {
     margin: 0;
     padding: var(--space) calc(2 * var(--space));
+    word-wrap: anywhere;
 }
 
 .json-display dl dt,


### PR DESCRIPTION
This fixes the bug where DataDisplay is taking the whole available space