### PR TITLE
Fixed chain issue for autoname

### DIFF
--- a/src/ui/views/Dashboard/Tabs/Details/SubTabs/Charts.tsx
+++ b/src/ui/views/Dashboard/Tabs/Details/SubTabs/Charts.tsx
@@ -153,7 +153,11 @@ const ChartTitle = ({ index, asset }: { asset: GetChartItemsResult[0]; index: nu
   );
   if (!assetName) {
     links.push(
-      <a target='_blank' href={`${apiProvider}/names?chain=${chain}&autoname=${asset.assetAddress}`} rel='noreferrer'>
+      <a
+        target='_blank'
+        href={`${apiProvider}/names?chain=${chain.chain}&autoname=${asset.assetAddress}`}
+        rel='noreferrer'
+      >
         Name
       </a>,
     );


### PR DESCRIPTION
Fixed the issue where chain is set as `[object Object]` in autoname call