### PR TITLE
Added removal of a trailing slash from CORE_URL

### DIFF
--- a/src/ui/State.tsx
+++ b/src/ui/State.tsx
@@ -296,10 +296,12 @@ export const useGlobalState2 = () => {
   const apiProvider = new URL(process.env.CORE_URL || 'http://localhost:8080');
   const host = apiProvider.hostname;
   const port = parseInt(apiProvider.port, 10);
+
   return ({
     host,
     port,
-    apiProvider: apiProvider.href,
+    // Remove trailing slash if any
+    apiProvider: apiProvider.href.replace(/\/$/, ''),
   });
 };
 


### PR DESCRIPTION
When user sets `CORE_URL` variable in their `.env` file to a value that ends with `/`, our code produces URLs with double `/`, e.g. `http://example.com//names`. This would still work for simple GET requests, but for anything more advanced the preflight OPTIONS request would fail because the URLs don't match.

This PR fixes the issue.